### PR TITLE
addeed partial results collections by simulating real-time streaming

### DIFF
--- a/recognise.go
+++ b/recognise.go
@@ -109,7 +109,7 @@ func (r *Recogniser) collectResponses(c chan recogResult) chan recogResult {
 			}
 		}
 	}
-	log.Logger.Debugf("< all responses recevied")
+	log.Logger.Debugf("< all responses received")
 	return c
 }
 

--- a/recogniser.go
+++ b/recogniser.go
@@ -17,8 +17,9 @@ import (
 )
 
 type Recogniser struct {
-	conn   *grpc.ClientConn
-	client pb.RecognizerClient
+	conn         *grpc.ClientConn
+	client       pb.RecognizerClient
+	streamClient grpc.BidiStreamingClient[pb.RecognitionStreamingRequest, pb.RecognitionStreamingResponse]
 }
 
 func NewRecogniser(url string, tokenFile string) (*Recogniser, error) {


### PR DESCRIPTION
Now audio is send simulating real time, so the audio is send in 800 bytes chunks (100 ms for 8 kHz, and 50 ms for 16 kHz), and it waits for 100 ms before sending the next chunk. Therefore, we can simulate RT 1, latencies, turn-detection, etc.

Beware that currently it only works with 8 kHz audio files, though.

Sending the audio in real-time we can now observe how partial results work. If you send the audio all at once, then you will only get final results on the whole audio